### PR TITLE
remove duplicate params

### DIFF
--- a/testing/mci.yml
+++ b/testing/mci.yml
@@ -5,7 +5,6 @@ tasks:
     - command: git.get_project
       params:
         directory: src
-      params:
         working_dir: src
         script: echo "lagos"
 buildvariants:


### PR DESCRIPTION
This breaks on yaml-v3, and apparently we use this file for our tests.